### PR TITLE
Raise an exception for 4xx and 5xx status codes and print the content

### DIFF
--- a/percy/connection.py
+++ b/percy/connection.py
@@ -15,6 +15,11 @@ class Connection(object):
             'User-Agent': self.user_agent,
         }
         response = requests.get(path, headers=headers)
+        try:
+            response.raise_for_status()
+        except Exception as e:
+            print(response.content)
+            raise e
         return response.json()
 
     def post(self, path, data, options={}):
@@ -24,6 +29,11 @@ class Connection(object):
             'User-Agent': self.user_agent,
         }
         response = requests.post(path, json=data, headers=headers)
+        try:
+            response.raise_for_status()
+        except Exception as e:
+            print(response.content)
+            raise e
         # TODO(fotinakis): exception handling.
         # response.raise_for_status()
         return response.json()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ test_requirements = [
 
 setup(
     name='percy',
-    version='1.0.4',
+    version='1.0.5',
     description='Python client library for visual regression testing with Percy (https://percy.io).',
     author='Perceptual Inc.',
     author_email='team@percy.io',


### PR DESCRIPTION
This is to help out debugging. Before this, my error messages on CircleCI were like:
```
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_integration.py", line 126, in test_integration
    name='dash_core_components - {}'.format(python_version)
  File "/home/ubuntu/dash-core-components/.tox/py27/lib/python2.7/site-packages/percy/runner.py", line 84, in snapshot
    missing_resources = snapshot_data['data']['relationships']['missing-resources']
KeyError: 'data'
```

After this, my error messages are a little more informative:
```
{"errors":[{"status":"bad_request","detail":"Invalid URL or path: ,"}]}
E
======================================================================
ERROR: test_integration (test.test_integration.Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_integration.py", line 126, in test_integration
    name='dash_core_components - {}'.format(python_version)
  File "/home/ubuntu/dash-core-components/.tox/py27/lib/python2.7/site-packages/percy/runner.py", line 82, in snapshot
    snapshot_data = self.client.create_snapshot(build_id, [root_resource], **kwargs)
  File "/home/ubuntu/dash-core-components/.tox/py27/lib/python2.7/site-packages/percy/client.py", line 104, in create_snapshot
    return self._connection.post(path=path, data=data)
  File "/home/ubuntu/dash-core-components/.tox/py27/lib/python2.7/site-packages/percy/connection.py", line 36, in post
    raise e
HTTPError: 400 Client Error: Bad Request for url: https://percy.io/api/v1/builds/319715/snapshots/
```