### PR TITLE
Update makefile to use twine for dist upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,9 @@ bumpversion_major: clean
 release: clean
 	git push
 	git push --tags
-	python setup.py register
-	python setup.py sdist upload
-	python setup.py bdist_wheel upload
+	python setup.py sdist
+	python setup.py bdist_wheel
+	twine upload dist/*
 
 dist: clean
 	python setup.py sdist

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,5 +7,6 @@ flake8==2.4.1
 pytest==2.8.3
 requests_mock==1.0.0
 tox==2.1.1
+twine==1.11.0
 watchdog==0.8.3
 wheel==0.23.0


### PR DESCRIPTION
Based on a deprecation warning trying to use current make versions, I've updated the `make release` method to use `twine` to upload dist files.

The `upload` commands were removed as well as the `register` line and replaced with a `twine` command, all based on suggestions here: https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi