### PR TITLE
don't use CIRCLE_WORKFLOW_WORKSPACE_ID for parallel nonce anymore

### DIFF
--- a/percy/environment.py
+++ b/percy/environment.py
@@ -251,7 +251,7 @@ class CircleEnvironment(object):
 
     @property
     def parallel_nonce(self):
-        return os.getenv('CIRCLE_WORKFLOW_WORKSPACE_ID') or os.getenv('CIRCLE_BUILD_NUM')
+        return os.getenv('CIRCLE_BUILD_NUM')
 
     @property
     def parallel_total_shards(self):


### PR DESCRIPTION
First off - thanks for the integration.  Percy has been super useful to us and has helped us be more proactive in finding visual differences.

I've been dealing with a maddening issue for a few weeks and I think I have a solution...

When running tests in parallel on CircleCI (such as using the nose-parallel plugin,) retrying a job will result in failures such as follows:

`HTTPError: 409 Client Error: Conflict for url: https://percy.io/api/v1/builds/0000000/snapshots/`

or 
`requests.exceptions.HTTPError: 409 Client Error: Conflict for url: https://percy.io/api/v1/builds/0000000/finalize
`

It appears that in retries, `CIRCLE_WORKFLOW_WORKSPACE_ID` does _not_ actually change. I don't think we should be using it as a parallel nonce.  

Without this fix, when we retry a selenium job on circleci, all our percy snapshots will fail.  We have to do a strange workaround of making an extra commit just to get the snapshots to be submitted properly.  

thanks! 