### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,9 @@ end_of_line = lf
 indent_style = tab
 end_of_line = crlf
 
+[*.yml]
+indent_size = 2
+
 [LICENSE]
 insert_final_newline = false
 

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# vscode config
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,14 @@ python:
   - 3.6
   - 3.7
 
-env:
-  - TOXENV=py35
-  - TOXENV=py34
-  - TOXENV=py27
-  # - TOXENV=py26
-  # - TOXENV=pypy
+
+matrix:
+  fast_finish: true
+  include:
+    - name: flake8-test
+      python: 3.7
+      install: pip install -U flake8
+      script: flake8 percy tests
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@
 # This file will be regenerated if you run travis_pypi_setup.py
 
 language: python
-python: 3.5
+python:
+  - 2.7
+  - 3.5
+  - 3.6
+  - 3.7
 
 env:
   - TOXENV=py35
@@ -12,7 +16,7 @@ env:
   # - TOXENV=pypy
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -U tox
+install: pip install -U tox-travis
 
 # command to run tests, e.g. python setup.py test
 script: tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,4 @@ recursive-include tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
-recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
+# recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,19 +16,6 @@ environment:
       PYTHON_VERSION: '2.7'
       PYTHON_ARCH: '64'
 
-    - TOXENV: 'py34'
-      TOXPYTHON: C:\Python34\python.exe
-      PYTHON_HOME: C:\Python34
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py34'
-      TOXPYTHON: C:\Python34-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\Python34-x64
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '64'
-
     - TOXENV: 'py35'
       TOXPYTHON: C:\Python35\python.exe
       PYTHON_HOME: C:\Python35
@@ -41,18 +28,29 @@ environment:
       PYTHON_VERSION: '3.5'
       PYTHON_ARCH: '64'
 
-    # Python 3.6 fails with: "Failed to build cryptography"
-    # - TOXENV: 'py36'
-    #   TOXPYTHON: C:\Python36\python.exe
-    #   PYTHON_HOME: C:\Python36
-    #   PYTHON_VERSION: '3.6'
-    #   PYTHON_ARCH: '32'
-    #
-    # - TOXENV: 'py36'
-    #   TOXPYTHON: C:\Python36-x64\python.exe
-    #   PYTHON_HOME: C:\Python36-x64
-    #   PYTHON_VERSION: '3.6'
-    #   PYTHON_ARCH: '64'
+    - TOXENV: 'py36'
+      TOXPYTHON: C:\Python36\python.exe
+      PYTHON_HOME: C:\Python36
+      PYTHON_VERSION: '3.6'
+      PYTHON_ARCH: '32'
+
+    - TOXENV: 'py36'
+      TOXPYTHON: C:\Python36-x64\python.exe
+      PYTHON_HOME: C:\Python36-x64
+      PYTHON_VERSION: '3.6'
+      PYTHON_ARCH: '64'
+
+    - TOXENV: 'py37'
+      TOXPYTHON: C:\Python37\python.exe
+      PYTHON_HOME: C:\Python37
+      PYTHON_VERSION: '3.7'
+      PYTHON_ARCH: '32'
+
+    - TOXENV: 'py37'
+      TOXPYTHON: C:\Python37-x64\python.exe
+      PYTHON_HOME: C:\Python37-x64
+      PYTHON_VERSION: '3.7'
+      PYTHON_ARCH: '64'
 
 init:
   - ps: echo $env:TOXENV

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,5 @@
 # Dev dependencies
 bump2version>=0.5.11
-flake8>=3.7.8
 watchdog>=0.9.0
 wheel>=0.33.4
 
@@ -11,3 +10,4 @@ requests==2.22.0
 requests_mock==1.6.0
 pytest>=2.8.3
 tox>=3.4.0
+flake8>=3.7.8

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,11 +1,13 @@
-PyYAML==5.1
-Sphinx==1.3.1
-bumpversion==0.5.3
-coverage==4.5.3
-cryptography==1.0.1
-flake8==3.7.8
-pytest==2.8.3
+# Dev dependencies
+bump2version>=0.5.11
+flake8>=3.7.8
+watchdog>=0.9.0
+wheel>=0.33.4
+
+# Runtime dependency
+requests==2.22.0
+
+# Test dependency
 requests_mock==1.6.0
-tox==2.1.1
-watchdog==0.9.0
-wheel==0.33.4
+pytest>=2.8.3
+tox>=3.4.0

--- a/setup.py
+++ b/setup.py
@@ -36,10 +36,11 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     test_suite='tests',
     tests_require=test_requirements
 )

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,11 @@ setup(
     license='MIT',
     zip_safe=False,
     keywords='percy',
+    project_urls={
+        "Documentation": "https://percy.io/docs/clients/python/selenium",
+        "Source": "https://github.com/percy/python-percy-client",
+        "Tracker": "https://github.com/percy/python-percy-client/issues",
+    },
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -11,7 +11,7 @@ class TestPercyUserAgent(unittest.TestCase):
     def test_string(self):
         self.assertTrue(
             re.match(
-                '^Percy/v1 python-percy-client/[.\d]+ \(python/[.\d]+(; travis)?\)$',
+                r'^Percy/v1 python-percy-client/[.\d]+ \(python/[.\d]+(; travis)?\)$',
                 str(UserAgent(self.config, self.environment))
             )
         )

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
-envlist = py27, py33, py34, py35
+minversion = 3.4.0
+envlist = py{27,35,36,37}
 
 [testenv]
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/percy
 deps =
     -r{toxinidir}/requirements_dev.txt
 commands =
-    py.test --basetemp={envtmpdir}
+    py.test --basetemp={envtmpdir} tests
 
 
 ; If you want to make tox run the tests with the same versions, create a

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,11 @@
 [tox]
 minversion = 3.4.0
-envlist = py{27,35,36,37}
+envlist = py{27,35,36,37}, flake8
+
+[testenv:flake8]
+basepython=python
+deps=flake8
+commands=flake8 percy tests
 
 [testenv]
 deps =


### PR DESCRIPTION
Atm the CI tests fail since the `requirements_dev.txt` contains dependecies which are fixed, outdated and often not needed (i.e. `cryptography` which breaks the build).

This PR:
- Drops unnesessary dependecys
- Releases the fixed version of dependencies which aren't runtime dependencies
- Drops deprecated python versions
- Adds flake8 testing to the tests on travis-ci

__Note:__
The build is breaking due to the failing `flake8` test. I didn't fix this since most project don't like white space or formation changes. But if you want I can format the code pep8 conform as done [here](https://travis-ci.org/s-weigand/python-percy-client).

Since this PR releases fixed versions this closes #90 #89 #84 #80 #79